### PR TITLE
README: Add warning on binding `eglot-x-on-enter` with a remap

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ positions.
 - [Join Lines]: see defun `eglot-x-join-lines`.
 - [Move Item]: see defun `eglot-x-move-item-down` and `eglot-x-move-item-up`.
 - [On Enter]: see defun `eglot-x-on-enter`.
+
+> [!WARNING]
+> Do **not** bind `eglot-x-on-enter` by remapping `newline` in the Eglot map, like in this example:
+> ```emacs-lisp
+>(use-package eglot-x
+> (:map eglot-mode-map
+>  ([remap newline] . eglot-x-on-enter)))
+>```
+> As that could break the fallback used when the server doesn't provide this extension.
+
 - [Matching Brace]: see `eglot-x-matching-brace`.
   However, emacs' own `backward-sexp`, and `forward-sexp` seem to be
   more useful.


### PR DESCRIPTION
* README.md (eglot-x-on-enter): Add a warning against remapping `newline`.

[Link for preview](https://github.com/gs-101/eglot-x/tree/docs/eglot-x-on-enter?tab=readme-ov-file#experimental-extensions).

I was going to file an issue for this, then I quickly realized my mistake, so I decided that a warning for other users would be fitting.

I can rebase this PR for any changes you suggest.

EDIT: I see that in that in the open issues and PRs you mention adding this to ELPA. I already assigned copyright to the FSF (to Emacs core, not sure if it's valid for ELPA), so no issues on this part.