### PR TITLE
Add autoload cookie to `eglot-x-setup`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Add the following lines to your init file to enable eglot-x
 
 ```elisp
     (with-eval-after-load 'eglot
-      (require 'eglot-x)
       (eglot-x-setup))
 ```
 To adjust which extensions are enabled:

--- a/eglot-x.el
+++ b/eglot-x.el
@@ -282,6 +282,7 @@ documentation functions in the order of their priories."
 ;;
 (defvar eglot-x--enabled nil)
 
+;;;####autoload
 (defun eglot-x-setup ()
   "Set up eglot-x to extend Eglot's feature-set.
 Call it when there are no active LSP servers."


### PR DESCRIPTION
That way we don't need to call `(require 'eglot-x)` before calling `eglot-x-setup`.