### PR TITLE
Should server be passed to eglot--apply-workspace-edit call?

### DIFF
--- a/eglot-x.el
+++ b/eglot-x.el
@@ -2288,7 +2288,7 @@ It relys on a rust-analyzer LSP extension."
                 (eglot-server-capable :codeActionProvider :resolveProvider))
            (eglot-execute server
                           (eglot--request server :codeAction/resolve action))
-         (when edit (eglot--apply-workspace-edit edit this-command))
+         (when edit (eglot--apply-workspace-edit server edit this-command))
          (when command
            (eglot-x-execute-command server command)))))))
 


### PR DESCRIPTION
I'm not entirely sure this is correct but without it I get I keep getting this error

> Wrong number of arguments: #<subr eglot--apply-workspace-edit>, 2

I think was changed recently in https://github.com/emacs-mirror/emacs/commit/cd1a372ccf28903cc05dc30c11c8fe89d4493513

since that's part of emacs I guess keeping compatibility for older emacsen might be a problem. 

